### PR TITLE
feat: update GearData interface and add migrate function

### DIFF
--- a/.changeset/metal-buses-watch.md
+++ b/.changeset/metal-buses-watch.md
@@ -1,0 +1,5 @@
+---
+'@malib/gear': minor
+---
+
+feat: update GearData interface and add migrate function

--- a/packages/gear/README.md
+++ b/packages/gear/README.md
@@ -39,16 +39,12 @@ pnpm add @malib/gear
 
 `GearData` 객체를 생성하는 별도의 기능은 없으며 직접 생성해야 합니다.
 
-라이브러리 업데이트로 인해 `GearData`의 형태가 변경될 경우 `meta.version` 속성에 반영되며, 기존의 장비를 새로운 버전으로 변환하는 함수가 제공됩니다.
-
 ```ts
 import { type GearData, type GearType } from '@malib/gear';
 
 const data: GearData = {
-  meta: {
-    id: 1009876,
-    version: 1,
-  },
+  version: 2,
+  id: 1009876,
   name: 'Example cap',
   icon: '1000000',
   type: GearType.cap,
@@ -58,7 +54,25 @@ const data: GearData = {
 };
 ```
 
+### Migrating GearData
+
+라이브러리 업데이트로 인해 `GearData`의 형태가 변경될 경우 `version` 속성에 반영되며, `migrate` 함수를 사용해 기존의 데이터를 새로운 버전으로 변환할 수 있습니다. 별도의 데이터 검증은 수행하지 않습니다.
+
+```ts
+import { migrate } from '@malib/gear';
+
+const dataV2 = migrate(data, 2);
+
+try {
+  const invalid = migrate({}, 2);
+} catch (e) {
+  console.log(e); // 입력 데이터가 유효하지 않습니다.
+}
+```
+
 ### Creating ReadonlyGear
+
+`ReadonlyGear` 및 `Gear`를 생성 시 오직 데이터의 `version` 속성만을 검사합니다.
 
 ```ts
 import { ReadonlyGear } from '@malib/gear';

--- a/packages/gear/src/index.ts
+++ b/packages/gear/src/index.ts
@@ -13,7 +13,6 @@ export {
   /* GearData */
   GearGender,
   type GearData,
-  type GearMetadata,
   type GearShapeData,
   type GearReqData,
   type GearBaseOption,
@@ -104,6 +103,7 @@ export {
   canApplyScroll,
   applyScroll,
 } from './lib/enhance/upgrade';
+export { migrate } from './lib/manage/migrate';
 export { Gear } from './lib/Gear';
 export { ReadonlyGear } from './lib/ReadonlyGear';
 export { GearAttribute } from './lib/GearAttribute';

--- a/packages/gear/src/lib/ReadonlyGear.test.ts
+++ b/packages/gear/src/lib/ReadonlyGear.test.ts
@@ -7,20 +7,28 @@ import {
 } from './test';
 
 describe('ReadonlyGear', () => {
-  describe('meta', () => {
+  describe('version', () => {
     const gear = createReadonlyGear();
-
-    it('id 속성을 포함한다.', () => {
-      expect(gear.meta.id).toBe(1000000);
+    it('2이다.', () => {
+      expect(gear.version).toBe(2);
     });
 
-    it('version이 1이다.', () => {
-      expect(gear.meta.version).toBe(1);
+    it('직접 설정할 수 없다.', () => {
+      // @ts-expect-error: Cannot assign to 'version' because it is a read-only property.
+      expect(() => (gear.version = 1)).toThrow();
+    });
+  });
+  
+  describe('id', () => {
+    const gear = createReadonlyGear();
+
+    it('1000000이다.', () => {
+      expect(gear.id).toBe(1000000);
     });
 
     it('직접 설정할 수 없다.', () => {
       // @ts-expect-error: Cannot assign to 'id' because it is a read-only property.
-      expect(() => (gear.meta = { id: 0, version: 1 })).toThrow();
+      expect(() => (gear.id = 0)).toThrow();
     });
   });
 

--- a/packages/gear/src/lib/ReadonlyGear.ts
+++ b/packages/gear/src/lib/ReadonlyGear.ts
@@ -4,7 +4,6 @@ import {
   GearBaseOption,
   GearData,
   GearExceptionalOption,
-  GearMetadata,
   GearShapeData,
   GearStarforceOption,
   GearType,
@@ -12,9 +11,11 @@ import {
   PotentialGrade,
   ReadonlySoulData,
   SoulChargeOption,
+  VERSION,
 } from './data';
 import { ReadonlyPotential } from './enhance/potential';
 import { getMaxStar } from './enhance/starforce';
+import { ErrorMessage, GearError } from './errors';
 import { GearAttribute } from './GearAttribute';
 import { sumOptions, toGearOption } from './gearOption';
 import { GearReq } from './GearReq';
@@ -43,8 +44,14 @@ export class ReadonlyGear implements _Gear {
   /**
    * 장비 정보를 참조하는 장비 인스턴스를 생성합니다.
    * @param data 장비 정보.
+   * 
+   * @throws {@link GearError}
+   * 지원하지 않는 장비 정보 버전일 경우.
    */
   constructor(data: GearData) {
+    if (data.version as unknown !== VERSION) {
+      throw new GearError(ErrorMessage.Constructor_InvalidVersion, { id: data.id, name: data.name }, { expected: VERSION, actual: data.version });
+    }
     this._data = data;
   }
 
@@ -56,10 +63,17 @@ export class ReadonlyGear implements _Gear {
   }
 
   /**
-   * 장비 메타데이터
+   * 장비 정보 버전
    */
-  get meta(): GearMetadata {
-    return this.data.meta;
+  get version(): typeof VERSION {
+    return this.data.version;
+  }
+  
+  /**
+   * 장비 ID
+   */
+  get id(): number {
+    return this.data.id;
   }
 
   /**
@@ -73,7 +87,7 @@ export class ReadonlyGear implements _Gear {
    * 장비 아이콘
    */
   get icon(): string {
-    return this.data.icon ?? '';
+    return this.data.icon;
   }
 
   /**

--- a/packages/gear/src/lib/data/GearData.ts
+++ b/packages/gear/src/lib/data/GearData.ts
@@ -6,18 +6,22 @@ import { PotentialData } from './PotentialData';
 import { PotentialGrade } from './PotentialGrade';
 import { SoulSlotData } from './SoulSlotData';
 
+export const VERSION = 2;
+
 /**
  * 장비 정보
  */
 export interface GearData {
-  /** 장비 메타데이터 */
-  meta: GearMetadata;
+  /** 장비 정보 버전 */
+  version: typeof VERSION;
+  /** 아이템 ID */
+  id: number;
   /** 장비명 */
   name: string;
-  /** 장비 아이콘 */
-  icon?: string;
   /** 장비 설명 */
   desc?: string;
+  /** 장비 아이콘 */
+  icon: string;
   /** 장비 외형 */
   shape?: GearShapeData;
   /** 장비 분류 */
@@ -69,20 +73,6 @@ export interface GearData {
   exceptionalUpgradeCount?: number;
   /** 익셉셔널 강화 가능 횟수 */
   exceptionalUpgradeableCount?: number;
-}
-
-/**
- * 장비 메타데이터
- *
- * 사용자는 메타데이터에 커스텀 속성을 추가할 수 있습니다.
- * 커스텀 속성은 해당 라이브러리가 임의로 변경하지 않습니다.
- * 충돌을 방지하기 위해 커스텀 속성명은 하나의 `_`으로 시작해야 합니다.
- */
-export interface GearMetadata {
-  /** 아이템 ID */
-  id: number;
-  /** 장비 정보 버전 */
-  version: 1;
 }
 
 /**

--- a/packages/gear/src/lib/errors.ts
+++ b/packages/gear/src/lib/errors.ts
@@ -1,5 +1,3 @@
-import { ReadonlyGear } from './ReadonlyGear';
-
 export class GearError extends Error {
   readonly gearId: number;
   readonly gearName: string;
@@ -7,12 +5,12 @@ export class GearError extends Error {
 
   constructor(
     message: string,
-    gear: ReadonlyGear,
+    gear: { id: number, name: string },
     status: Record<string, unknown>,
   ) {
     super(message);
     this.name = 'GearError';
-    this.gearId = gear.meta.id;
+    this.gearId = gear.id;
     this.gearName = gear.name;
     this.status = status;
   }
@@ -60,4 +58,11 @@ export const enum ErrorMessage {
 
   Exceptional_InvalidEnhanceGear = '익셉셔널 강화를 적용할 수 없는 상태의 장비입니다.',
   Exceptional_InvalidResetGear = '익셉셔널 강화를 초기화할 수 없는 장비입니다.',
+
+  Constructor_InvalidVersion = '지원하지 않는 장비 정보 버전입니다. 업그레이드 후 생성해야 합니다.',
+  
+  Migrate_InvalidGearData = '입력 데이터가 유효하지 않습니다.',
+  Migrate_UnknownDataVersion = '입력 데이터의 버전이 잘못되었습니다.',
+  Migrate_DataVersionTooNew = '입력 데이터의 버전이 지원하는 버전보다 최신입니다.',
+  Migrate_DataPropertyWillBeOverwritten = '입력 데이터의 속성이 덮어쓰여집니다. 제거하고 다시 실행해 주세요.',
 }

--- a/packages/gear/src/lib/manage/migrate.test.ts
+++ b/packages/gear/src/lib/manage/migrate.test.ts
@@ -1,0 +1,101 @@
+import { GearType } from "../data";
+import { migrate } from "./migrate";
+
+describe('migrate', () => {
+  it('GearDataV1을 GearDataV2로 마이그레이션한다.', () => {
+    const data = {
+      meta: {
+        id: 1000000,
+        version: 1,
+      },
+      name: '테스트용 장비',
+      type: GearType.cap,
+      req: {},
+      attributes: {},
+    };
+    expect(migrate(data)).toEqual({
+      id: 1000000,
+      version: 2,
+      name: '테스트용 장비',
+      type: GearType.cap,
+      req: {},
+      attributes: {},
+    });
+  });
+
+  it('GearDataV2를 GearDataV2로 마이그레이션한다.', () => {
+    const data = {
+      id: 1000000,
+      version: 2,
+      name: '테스트용 장비',
+      type: GearType.cap,
+      req: {},
+      attributes: {},
+    };
+    expect(migrate(data)).toEqual(data);
+  });
+
+  it('GearDataV3을 전달하면 TypeError가 발생한다.', () => {
+    const data = {
+      id: 1000000,
+      version: 3,
+      name: '테스트용 장비',
+      type: GearType.cap,
+    };
+    expect(() => migrate(data)).toThrow(TypeError);
+  });
+
+  it('빈 객체를 전달하면 TypeError가 발생한다.', () => {
+    expect(() => migrate({})).toThrow(TypeError);
+  });
+
+  it('GearDataV1에서 id가 숫자가 아닌 경우 TypeError가 발생한다.', () => {
+    const data = {
+      meta: {
+        id: '1000000',
+        version: 1,
+      },
+      name: '테스트용 장비',
+      type: GearType.cap,
+      req: {},
+      attributes: {},
+    };
+    expect(() => migrate(data)).toThrow(TypeError);
+  });
+
+  it('GearDataV1에서 id가 없는 경우 TypeError가 발생한다.', () => {
+    const data = {
+      meta: {
+        version: 1,
+      },
+      name: '테스트용 장비',
+      type: GearType.cap,
+    };
+    expect(() => migrate(data)).toThrow(TypeError);
+  });
+
+  it('GearData에 포함되지 않는 속성도 함께 마이그레이션한다.', () => {
+    const data = {
+      id: 1000000,
+      version: 2,
+      name: '테스트용 장비',
+      type: GearType.cap,
+      req: {
+        unknown: 123,
+      },
+      attributes: {},
+      unknown: 'unknown',
+    };
+    expect(migrate(data)).toEqual({
+      id: 1000000,
+      version: 2,
+      name: '테스트용 장비',
+      type: GearType.cap,
+      req: {
+        unknown: 123,
+      },
+      attributes: {},
+      unknown: 'unknown',
+    });
+  });
+});

--- a/packages/gear/src/lib/manage/migrate.ts
+++ b/packages/gear/src/lib/manage/migrate.ts
@@ -1,0 +1,48 @@
+import { VERSION } from '../data';
+import { ErrorMessage } from '../errors';
+import { getVersion } from './version';
+
+export function migrate(data: object, version: number = VERSION): object {
+  const currentVersion = getVersion(data);
+  if (currentVersion === undefined) {
+    throw new TypeError(ErrorMessage.Migrate_InvalidGearData);
+  }
+  if (currentVersion > version) {
+    throw new TypeError(ErrorMessage.Migrate_DataVersionTooNew);
+  }
+  if (currentVersion === version) {
+    return data;
+  }
+  switch (currentVersion) {
+    case 1:
+      return migrateV1ToV2(data);
+    default:
+      throw new TypeError(ErrorMessage.Migrate_UnknownDataVersion);
+  }
+}
+
+function migrateV1ToV2(data: object): object {
+  if (
+    ('id' in data && data.id !== undefined) ||
+    ('version' in data && data.version !== undefined)
+  ) {
+    throw new TypeError(ErrorMessage.Migrate_DataPropertyWillBeOverwritten);
+  }
+  if (
+    !(
+      'meta' in data &&
+      typeof data.meta === 'object' &&
+      data.meta !== null &&
+      'id' in data.meta &&
+      typeof data.meta.id === 'number'
+    )
+  ) {
+    throw new TypeError('Assert: id should exist');
+  }
+  const { meta, ...rest } = data;
+  return {
+    ...rest,
+    id: meta.id,
+    version: 2,
+  };
+}

--- a/packages/gear/src/lib/manage/version.test.ts
+++ b/packages/gear/src/lib/manage/version.test.ts
@@ -1,0 +1,43 @@
+import { GearData, GearType } from '../data';
+import { getVersion } from './version';
+
+describe('getVersion', () => {
+  it('GearDataV1에서 1을 추출한다.', () => {
+    const data = {
+      meta: {
+        id: 1000000,
+        version: 1,
+      },
+      name: '테스트용 장비',
+      type: GearType.cap,
+      req: {},
+      attributes: {},
+    };
+    expect(getVersion(data)).toBe(1);
+  });
+
+  it('GearDataV2에서 2를 추출한다.', () => {
+    const data = {
+      id: 1000000,
+      version: 2,
+      name: '테스트용 장비',
+      icon: '1000000',
+      type: GearType.cap,
+      req: {},
+      attributes: {},
+    } satisfies GearData;
+    expect(getVersion(data)).toBe(2);
+  });
+
+  it('빈 객체인 경우 undefined를 반환한다.', () => {
+    expect(getVersion({})).toBeUndefined();
+  });
+
+  it('GearDataV1에서 version이 숫자가 아닌 경우 undefined를 반환한다.', () => {
+    expect(getVersion({ meta: { id: 1000000, version: '2' } })).toBeUndefined();
+  });
+
+  it('GearDataV2+에서 version이 숫자가 아닌 경우 undefined를 반환한다.', () => {
+    expect(getVersion({ id: 1000000, version: '2' })).toBeUndefined();
+  });
+});

--- a/packages/gear/src/lib/manage/version.ts
+++ b/packages/gear/src/lib/manage/version.ts
@@ -1,0 +1,19 @@
+export function getVersion(data: object): number | undefined {
+  // V1
+  if ('meta' in data) {
+    const meta = data.meta;
+    if (
+      typeof meta === 'object' &&
+      meta !== null &&
+      'version' in meta &&
+      typeof meta.version === 'number'
+    ) {
+      return meta.version;
+    }
+  }
+  // V2+
+  if ('version' in data && typeof data.version === 'number') {
+    return data.version;
+  }
+  return undefined;
+}

--- a/packages/gear/src/lib/test/gearFixtureResources.ts
+++ b/packages/gear/src/lib/test/gearFixtureResources.ts
@@ -2,10 +2,8 @@ import { GearData, GearType } from '../data';
 
 export const resources = {
   '': {
-    meta: {
-      id: 1000000,
-      version: 1,
-    },
+    id: 1000000,
+    version: 2,
     name: '테스트용 장비',
     icon: '1000000',
     type: 100,
@@ -13,10 +11,8 @@ export const resources = {
     attributes: {},
   },
   '핑크빈 모자': {
-    meta: {
-      id: 1003450,
-      version: 1,
-    },
+    id: 1003450,
+    version: 2,
     name: '핑크빈 모자',
     icon: '1002971',
     type: 100,
@@ -39,10 +35,8 @@ export const resources = {
     scrollUpgradeableCount: 11,
   },
   '리버스 휀넬': {
-    meta: {
-      id: 1002790,
-      version: 1,
-    },
+    id: 1002790,
+    version: 2,
     name: '리버스 휀넬',
     icon: '1002776',
     type: 100,
@@ -65,10 +59,8 @@ export const resources = {
     scrollUpgradeableCount: 8,
   },
   '노가다 목장갑': {
-    meta: {
-      id: 1082002,
-      version: 1,
-    },
+    id: 1082002,
+    version: 2,
     name: '노가다 목장갑',
     icon: '1082002',
     type: 108,
@@ -88,10 +80,8 @@ export const resources = {
     scrollUpgradeableCount: 6,
   },
   '튼튼한 기계 장갑': {
-    meta: {
-      id: 1082283,
-      version: 1,
-    },
+    id: 1082283,
+    version: 2,
     name: '튼튼한 기계 장갑',
     icon: '1082222',
     type: 108,
@@ -111,10 +101,8 @@ export const resources = {
     scrollUpgradeableCount: 6,
   },
   '블랙 가리나 글로브': {
-    meta: {
-      id: 1082167,
-      version: 1,
-    },
+    id: 1082167,
+    version: 2,
     name: '블랙 가리나 글로브',
     icon: '1082167',
     type: 108,
@@ -137,10 +125,8 @@ export const resources = {
     scrollUpgradeableCount: 6,
   },
   '펜살리르 스키퍼부츠': {
-    meta: {
-      id: 1072971,
-      version: 1,
-    },
+    id: 1072971,
+    version: 2,
     name: '펜살리르 스키퍼부츠',
     icon: '1072967',
     type: 107,
@@ -165,10 +151,8 @@ export const resources = {
     scrollUpgradeableCount: 7,
   },
   '앱솔랩스 시프슈즈': {
-    meta: {
-      id: 1073034,
-      version: 1,
-    },
+    id: 1073034,
+    version: 2,
     name: '앱솔랩스 시프슈즈',
     icon: '1073030',
     type: 107,
@@ -200,10 +184,8 @@ export const resources = {
     scrollUpgradeableCount: 8,
   },
   '노바 히아데스 클록': {
-    meta: {
-      id: 1102476,
-      version: 1,
-    },
+    id: 1102476,
+    version: 2,
     name: '노바 히아데스 클록',
     icon: '1102476',
     type: 110,
@@ -233,10 +215,8 @@ export const resources = {
     scrollUpgradeableCount: 2,
   },
   '타일런트 케이론 클록': {
-    meta: {
-      id: 1102483,
-      version: 1,
-    },
+    id: 1102483,
+    version: 2,
     name: '타일런트 케이론 클록',
     icon: '1102481',
     type: 110,
@@ -267,10 +247,8 @@ export const resources = {
     scrollUpgradeableCount: 3,
   },
   '에테르넬 나이트케이프': {
-    meta: {
-      id: 1103433,
-      version: 1,
-    },
+    id: 1103433,
+    version: 2,
     name: '에테르넬 나이트케이프',
     icon: '1103433',
     type: 110,
@@ -303,10 +281,8 @@ export const resources = {
     scrollUpgradeableCount: 8,
   },
   '스칼렛 숄더': {
-    meta: {
-      id: 1152155,
-      version: 1,
-    },
+    id: 1152155,
+    version: 2,
     name: '스칼렛 숄더',
     icon: '1152155',
     type: 115,
@@ -336,10 +312,8 @@ export const resources = {
     scrollUpgradeableCount: 2,
   },
   '카오스 혼테일의 목걸이': {
-    meta: {
-      id: 1122076,
-      version: 1,
-    },
+    id: 1122076,
+    version: 2,
     name: '카오스 혼테일의 목걸이',
     icon: '1122076',
     type: 112,
@@ -373,10 +347,8 @@ export const resources = {
     scrollUpgradeableCount: 3,
   },
   '데아 시두스 이어링': {
-    meta: {
-      id: 1032241,
-      version: 1,
-    },
+    id: 1032241,
+    version: 2,
     name: '데아 시두스 이어링',
     icon: '1032241',
     type: 103,
@@ -405,10 +377,8 @@ export const resources = {
     scrollUpgradeableCount: 7,
   },
   '몽환의 벨트': {
-    meta: {
-      id: 1132308,
-      version: 1,
-    },
+    id: 1132308,
+    version: 2,
     name: '몽환의 벨트',
     icon: '1132308',
     type: 113,
@@ -442,10 +412,8 @@ export const resources = {
     exceptionalUpgradeableCount: 1,
   },
   '스칼렛 링': {
-    meta: {
-      id: 1113070,
-      version: 1,
-    },
+    id: 1113070,
+    version: 2,
     name: '스칼렛 링',
     icon: '1113070',
     type: 111,
@@ -477,10 +445,8 @@ export const resources = {
     scrollUpgradeableCount: 2,
   },
   '근원의 속삭임': {
-    meta: {
-      id: 1113341,
-      version: 1,
-    },
+    id: 1113341,
+    version: 2,
     name: '근원의 속삭임',
     icon: '1113341',
     type: 111,
@@ -512,10 +478,8 @@ export const resources = {
     scrollUpgradeableCount: 4,
   },
   '데이브레이크 펜던트': {
-    meta: {
-      id: 1122443,
-      version: 1,
-    },
+    id: 1122443,
+    version: 2,
     name: '데이브레이크 펜던트',
     icon: '1122443',
     type: 112,
@@ -549,10 +513,8 @@ export const resources = {
     scrollUpgradeableCount: 6,
   },
   '리튬 하트': {
-    meta: {
-      id: 1672007,
-      version: 1,
-    },
+    id: 1672007,
+    version: 2,
     name: '리튬 하트',
     icon: '1672007',
     type: 167,
@@ -576,10 +538,8 @@ export const resources = {
     scrollUpgradeableCount: 8,
   },
   '페어리 하트': {
-    meta: {
-      id: 1672073,
-      version: 1,
-    },
+    id: 1672073,
+    version: 2,
     name: '페어리 하트',
     icon: '1672073',
     type: 167,
@@ -599,10 +559,8 @@ export const resources = {
     scrollUpgradeableCount: 10,
   },
   '리퀴드메탈 하트': {
-    meta: {
-      id: 1672077,
-      version: 1,
-    },
+    id: 1672077,
+    version: 2,
     name: '리퀴드메탈 하트',
     icon: '1672077',
     type: 167,
@@ -626,10 +584,8 @@ export const resources = {
     scrollUpgradeableCount: 10,
   },
   '컴플리트 언더컨트롤': {
-    meta: {
-      id: 1672095,
-      version: 1,
-    },
+    id: 1672095,
+    version: 2,
     name: '컴플리트 언더컨트롤',
     icon: '1672095',
     type: 167,
@@ -656,10 +612,8 @@ export const resources = {
     scrollUpgradeableCount: 10,
   },
   '쟈이힌 스태프': {
-    meta: {
-      id: 1382244,
-      version: 1,
-    },
+    id: 1382244,
+    version: 2,
     name: '쟈이힌 스태프',
     icon: '1382244',
     type: 138,
@@ -682,10 +636,8 @@ export const resources = {
     scrollUpgradeableCount: 8,
   },
   '앱솔랩스 ESP리미터': {
-    meta: {
-      id: 1262017,
-      version: 1,
-    },
+    id: 1262017,
+    version: 2,
     name: '앱솔랩스 ESP리미터',
     icon: '1262017',
     type: 126,
@@ -719,10 +671,8 @@ export const resources = {
     scrollUpgradeableCount: 9,
   },
   '아케인셰이드 샤이닝로드': {
-    meta: {
-      id: 1212120,
-      version: 1,
-    },
+    id: 1212120,
+    version: 2,
     name: '아케인셰이드 샤이닝로드',
     icon: '1212120',
     type: GearType.shiningRod,
@@ -754,10 +704,8 @@ export const resources = {
     scrollUpgradeableCount: 9,
   },
   '아케인셰이드 초선': {
-    meta: {
-      id: 1292018,
-      version: 1,
-    },
+    id: 1292018,
+    version: 2,
     name: '아케인셰이드 초선',
     icon: '1292018',
     type: 129,
@@ -789,10 +737,8 @@ export const resources = {
     scrollUpgradeableCount: 9,
   },
   '레드 보우': {
-    meta: {
-      id: 1452220,
-      version: 1,
-    },
+    id: 1452220,
+    version: 2,
     name: '레드 보우',
     icon: '1452220',
     type: 145,
@@ -815,10 +761,8 @@ export const resources = {
     scrollUpgradeableCount: 8,
   },
   '라즐리 9형': {
-    meta: {
-      id: 1572009,
-      version: 1,
-    },
+    id: 1572009,
+    version: 2,
     name: '라즐리 9형',
     icon: '1572009',
     type: 157,
@@ -846,10 +790,8 @@ export const resources = {
     scrollUpgradeableCount: 9,
   },
   '제네시스 브레스 슈터': {
-    meta: {
-      id: 1214022,
-      version: 1,
-    },
+    id: 1214022,
+    version: 2,
     name: '제네시스 브레스 슈터',
     icon: '1214021',
     type: 1214,

--- a/packages/gear/src/lib/testUtils.ts
+++ b/packages/gear/src/lib/testUtils.ts
@@ -3,11 +3,10 @@ import { Gear } from './Gear';
 
 export function defaultGear(data: Partial<GearData>): Gear {
   return new Gear({
-    meta: {
-      id: 1234567,
-      version: 1,
-    },
+    id: 1234567,
+    version: 2,
     name: '',
+    icon: '',
     type: GearType.cap,
     req: {},
     attributes: {},


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce GearData v2 (top-level version/id, required icon), add migrate/getVersion utilities, validate version in ReadonlyGear, and update docs/tests/fixtures.
> 
> - **Core types (`lib/data`)**:
>   - `GearData` v2: move `meta.version/id` to top-level `version`/`id`; make `icon` required; add `VERSION = 2`.
> - **ReadonlyGear**:
>   - Validate `data.version === VERSION` in constructor (throws `GearError` on mismatch).
>   - New getters: `version`, `id`; remove `meta` usage; `icon` now non-optional.
> - **Migration utilities**:
>   - Add `getVersion` and `migrate` (v1→v2), with error handling; export `migrate` from package.
> - **Errors**:
>   - `GearError` now accepts `{ id, name }`; add messages for constructor/migration failures.
> - **Tests/fixtures**:
>   - Update fixtures to v2 shape; add tests for version detection/migration; adjust `ReadonlyGear` tests.
> - **Docs**:
>   - README: update `GearData` example to v2 and add migration usage section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2d677b98225904b7f01deba716718287c67abff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->